### PR TITLE
Add README with setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Formula 1 Win Predictor
+
+This repository contains an experimental workflow to predict the winner of a Formula 1 race. It analyzes early laps and contextual information, trains various machine-learning models and outputs the driver most likely to win.
+
+## Installation
+
+1. **Enable Git LFS**
+   The project includes large files managed with Git Large File Storage. Ensure LFS is enabled so that notebook files are downloaded correctly:
+
+   ```bash
+   git lfs install
+   git lfs pull
+   ```
+
+2. **Install dependencies**
+   Use the requirements file to install Python packages:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+After setup, open `f1_win_predictor.ipynb` in Jupyter to explore the model. Configuration values are defined in `config.py`.


### PR DESCRIPTION
## Summary
- add a README describing the Formula 1 win predictor
- document enabling Git LFS and installing dependencies

## Testing
- `git lfs ls-files`


------
https://chatgpt.com/codex/tasks/task_e_686d3f600744833096e00338d614d042